### PR TITLE
point exposure calculation fix

### DIFF
--- a/RiskChanges/RiskChangesOps/writevector.py
+++ b/RiskChanges/RiskChangesOps/writevector.py
@@ -3,80 +3,106 @@ import pandas as pd
 import geopandas as gpd
 from sqlalchemy import create_engine
 
-def writeexposure(df,connstr,schema):  
+
+def writeexposure(df, connstr, schema):
+    engine = create_engine(connstr)
+    try:
+        df.to_sql('exposure_result', engine, schema,
+                  if_exists='append', index=False)
+        print('data written')
+
+    except:
+        # auto add its primary key
+        raise Exception(
+            "error, trying to append in non related table,please store in same table as Exposure")
+    engine.dispose()
+
+
+def writeexposureAgg(df, connstr, schema):
     engine = create_engine(connstr)
     print(engine)
     try:
-        df.to_sql('exposure_result', engine, schema,if_exists='append', index=False)
+        df.to_sql('exposure_result_agg', engine, schema,
+                  if_exists='append', index=False)
         print('data written')
 
     except:
-        print("error, trying to append in non related table,please store in same table as Exposure") #auto add its primary key
-    engine.dispose()
-
-def writeexposureAgg(df,connstr,schema):  
-    engine = create_engine(connstr)
-    print(engine)
-    try:
-        df.to_sql('exposure_result_agg', engine, schema,if_exists='append', index=False)
-        print('data written')
-
-    except:
-        print("error, trying to append in non related table,please store in same table as Exposure") #auto add its primary key
-    engine.dispose()
-
-    
-def writeLossAgg(df,connstr,schema):
-    engine = create_engine(connstr)
-    #print(engine)
-    try:
-        df.to_sql('loss_result_agg', engine, schema,if_exists='append', index=False)
-        print('data written')
-
-    except:
-        print("error, trying to append in non related table,please store in same table as Loss") #auto add its primary key
-    engine.dispose()
-
-def writeLoss(df,connstr,schema):
-    engine = create_engine(connstr)
-    #print(engine)
-    try:
-        df.to_sql('loss_result', engine, schema,if_exists='append', index=False)
-        print('data written')
-
-    except:
-        print("error, trying to append in non related table,please store in same table as Loss") #auto add its primary key
-    engine.dispose()
-
-def writeRisk(df,connstr,schema):
-    engine = create_engine(connstr)
-    #print(engine)
-    try:
-        df.to_sql('risk_result', engine, schema,if_exists='append', index=False)
-        print('data written')
-
-    except:
-        print("error, trying to append in non related table,please store in same table as Risk") #auto add its primary key
-    engine.dispose()
-def writeRiskAgg(df,connstr,schema):
-    engine = create_engine(connstr)
-    #print(engine)
-    try:
-        df.to_sql('risk_result_agg', engine, schema,if_exists='append', index=False)
-        print('data written')
-
-    except:
-        print("error, trying to append in non related table,please store in same table as Risk") #auto add its primary key
+        # auto add its primary key
+        raise Exception(
+            "error, trying to append in non related table,please store in same table as Exposure")
     engine.dispose()
 
 
-def writeRiskCombined(df,connstr,schema):
+def writeLossAgg(df, connstr, schema):
     engine = create_engine(connstr)
-    #print(engine)
+    # print(engine)
     try:
-        df.to_sql('risk_result_combined', engine, schema,if_exists='append', index=False)
+        df.to_sql('loss_result_agg', engine, schema,
+                  if_exists='append', index=False)
         print('data written')
 
     except:
-        print("error, trying to append in non related table,please store in same table as Risk") #auto add its primary key
+        # auto add its primary key
+        raise Exception(
+            "error, trying to append in non related table,please store in same table as Loss")
+    engine.dispose()
+
+
+def writeLoss(df, connstr, schema):
+    engine = create_engine(connstr)
+    # print(engine)
+    try:
+        df.to_sql('loss_result', engine, schema,
+                  if_exists='append', index=False)
+        print('data written')
+
+    except:
+        # auto add its primary key
+        raise Exception(
+            "error, trying to append in non related table,please store in same table as Loss")
+    engine.dispose()
+
+
+def writeRisk(df, connstr, schema):
+    engine = create_engine(connstr)
+    # print(engine)
+    try:
+        df.to_sql('risk_result', engine, schema,
+                  if_exists='append', index=False)
+        print('data written')
+
+    except:
+        # auto add its primary key
+        raise Exception(
+            "error, trying to append in non related table,please store in same table as Risk")
+    engine.dispose()
+
+
+def writeRiskAgg(df, connstr, schema):
+    engine = create_engine(connstr)
+    # print(engine)
+    try:
+        df.to_sql('risk_result_agg', engine, schema,
+                  if_exists='append', index=False)
+        print('data written')
+
+    except:
+        # auto add its primary key
+        raise Exception(
+            "error, trying to append in non related table,please store in same table as Risk")
+    engine.dispose()
+
+
+def writeRiskCombined(df, connstr, schema):
+    engine = create_engine(connstr)
+    # print(engine)
+    try:
+        df.to_sql('risk_result_combined', engine, schema,
+                  if_exists='append', index=False)
+        print('data written')
+
+    except:
+        # auto add its primary key
+        raise Exception(
+            "error, trying to append in non related table,please store in same table as Risk")
     engine.dispose()

--- a/RiskChanges/computeExposure.py
+++ b/RiskChanges/computeExposure.py
@@ -113,14 +113,27 @@ def lineExposure(ear, haz, expid, Ear_Table_PK):
 
 
 def pointExposure(ear, haz, expid, Ear_Table_PK):
-    coords = [(x,y) for x, y in zip(ear.geometry.x, ear.geometry.y)]
-    ear['class'] = [x for x in haz.sample(coords)]
-    ear['exposure_id'] = expid
-    ear['areaOrLen'] = 0
-    ear['exposed'] = 100
-    ear=ear.rename(columns={Ear_Table_PK:'geom_id' })
+    coords = [(x, y) for x, y in zip(ear.geometry.x, ear.geometry.y)]
+    df_temp = pd.DataFrame()
+    classes = []
+    for x in haz.sample(coords):
+        classes.append(x[0])
+    df_temp['class'] = classes
+    df_temp['exposure_id'] = expid
+    df_temp['areaOrLen'] = 0
+    df_temp['exposed'] = 100
+    df_temp['geom_id'] = ear[Ear_Table_PK]
     haz = None
-    return ear
+    return df_temp
+
+    # coords = [(x,y) for x, y in zip(ear.geometry.x, ear.geometry.y)]
+    # ear['class'] = [x for x in haz.sample(coords)]
+    # ear['exposure_id'] = expid
+    # ear['areaOrLen'] = 0
+    # ear['exposed'] = 100
+    # ear=ear.rename(columns={Ear_Table_PK:'geom_id' })
+    # haz = None
+    # return ear
 
 
 def ComputeExposure(con, earid, hazid, expid, **kwargs):
@@ -131,12 +144,12 @@ def ComputeExposure(con, earid, hazid, expid, **kwargs):
 
     ear = readear(con, earid)
     haz = readhaz(con, hazid, haz_file)
-    #assert vectorops.cehckprojection(
+    # assert vectorops.cehckprojection(
     #    ear, haz), "The hazard and EAR do not have same projection system please check it first"
     if vectorops.cehckprojection(ear, haz):
-        
+
         warnings.warn("The input co-ordinate system for hazard and EAR were differe, we have updated it for now on the fly but from next time please check your data before computation")
-        ear=vectorops.changeprojection(ear,haz)
+        ear = vectorops.changeprojection(ear, haz)
 
     metatable = readmeta.earmeta(con, earid)
     Ear_Table_PK = metatable.data_id[0]

--- a/RiskChanges/load_SHP.py
+++ b/RiskChanges/load_SHP.py
@@ -1,39 +1,16 @@
 import geopandas
-from geoalchemy2 import Geometry, WKTElement
 from sqlalchemy import *
 
 
 def loadshp(shpInput, connstr, lyrName, schema, index):
     geodataframe = geopandas.read_file(shpInput)
-    crs = geodataframe.crs
-    try:
-        epsg = crs.to_epsg()
-
-    except:
-        print('Warning! Coordinate system manually assigned to 4326. This might affect on visualization of data.')
-        epsg = 4326
 
     # Creating SQLAlchemy's engine to use
     engine = create_engine(connstr)
 
     geodataframe[index] = geodataframe.index
-    if 'geometry' not in geodataframe.columns:
-        raise ValueError(
-            "The input shapefile do not consist of 'geometry' column, please make sure it has geometry column (it can be with different name such as geom, in such case please rename it.)")
 
-    geodataframe['geom'] = geodataframe['geometry'].apply(
-        lambda x: WKTElement(x.wkt, srid=epsg))
+    geodataframe.to_postgis(name=lyrName, con=engine,
+                            schema=schema, if_exists='replace')
 
-    # drop the geometry column as it is now duplicative
-    geodataframe.drop('geometry', 1, inplace=True)
-
-    geodataframe.to_sql(lyrName, engine, schema, if_exists='replace', index=False,
-                        dtype={'geom': Geometry('Geometry', srid=epsg)})
     engine.dispose()
-
-
-#     crs_name = str(geodataframe.crs.srs)
-#     print(geodataframe.crs, 'crs')
-#     print(geodataframe.crs.to_epsg(), type(geodataframe.crs.to_epsg()), 'epsg')
-#     print(geodataframe.crs.srs, 'srs called')
-#     print(type(geodataframe.crs))

--- a/RiskChanges/load_SHP.py
+++ b/RiskChanges/load_SHP.py
@@ -18,7 +18,8 @@ def loadshp(shpInput, connstr, lyrName, schema, index):
 
     geodataframe[index] = geodataframe.index
     if 'geometry' not in geodataframe.columns:
-        raise ValueError("The input shapefile do not consist of 'geometry' column, please make sure it has geometry column (it can be with different name such as geom, in such case please rename it.)")
+        raise ValueError(
+            "The input shapefile do not consist of 'geometry' column, please make sure it has geometry column (it can be with different name such as geom, in such case please rename it.)")
 
     geodataframe['geom'] = geodataframe['geometry'].apply(
         lambda x: WKTElement(x.wkt, srid=epsg))


### PR DESCRIPTION
Hi Ashok, I tested the Nepal dataset and found that its `mean_area` is less than 100. Now it is trying to calculate the point exposure. I checked the point exposure calculation function and found the below code,

```python
def pointExposure(ear, haz, expid, Ear_Table_PK):
    coords = [(x,y) for x, y in zip(ear.geometry.x, ear.geometry.y)]
    ear['class'] = [x for x in haz.sample(coords)]
    ear['exposure_id'] = expid
    ear['areaOrLen'] = 0
    ear['exposed'] = 100
    ear=ear.rename(columns={Ear_Table_PK:'geom_id' })
    haz = None
    return ear
```

But in polygon and line exposure we store only a few columns in the exposure table, (class, exposure_id, areaOrLen, exposed, geom_id). That violates the exposure result merge issue. That is why I tried to change the calculation function as below and now it is working fine,

```python 
def pointExposure(ear, haz, expid, Ear_Table_PK):
    coords = [(x, y) for x, y in zip(ear.geometry.x, ear.geometry.y)]
    df_temp = pd.DataFrame()
    classes = []
    for x in haz.sample(coords):
        classes.append(x[0])
    df_temp['class'] = classes
    df_temp['exposure_id'] = expid
    df_temp['areaOrLen'] = 0
    df_temp['exposed'] = 100
    df_temp['geom_id'] = ear[Ear_Table_PK]
    haz = None
    return df_temp
```

Please review this PR and merge it if it is ok to do. Otherwise please suggest to me how to do it. 

PS: the exposure calculation for my test dataset working fine and I can visualize the result as well. 
